### PR TITLE
Adds a converter from the newly used Memory type to a Vector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,14 +6,18 @@ version = "0.3.1"
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 Retry = "20febd7b-183b-5ae2-ac4a-720e7ce64774"
 
+[compat]
+Random = "1.11.0"
+
 [extras]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 Parquet2 = "98572fba-bba0-415d-956f-fa77e587d26d"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [targets]
-test = ["Conda", "DataFrames", "EzXML", "Parquet2", "Pkg", "Test", "TestItemRunner"]
+test = ["Conda", "DataFrames", "EzXML", "Parquet2", "Pkg", "Random", "Test", "TestItemRunner"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "S3PATH"
 uuid = "94d20e9e-c806-4d6f-8ac0-01928ab83293"
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/src/S3PATH.jl
+++ b/src/S3PATH.jl
@@ -247,7 +247,7 @@ Base.write(s3Path::S3Path, content::AbstractString; blocksize=DEFAULTBUFFERSIZE)
     Base.write(s3Path::S3Path, Vector{UInt8}(content); blocksize=blocksize)
 
 Base.write(s3Path::S3Path, content::Memory{UInt8}; blocksize=DEFAULTBUFFERSIZE) =
-    Base.write(s3Path::S3Path, convert(Vector{UInt8}, copy(content)); blocksize=blocksize)
+    Base.write(s3Path::S3Path, convert(Vector{UInt8}, content); blocksize=blocksize)
 
 function Base.write(s3Path::S3Path, content::Vector{UInt8}; blocksize=DEFAULTBUFFERSIZE)
 
@@ -402,7 +402,7 @@ function Base.flush(io::S3WriteBuffer)
                 io.s3Path,
                 io.uploadid,
                 io.partnumber,
-                io.buffer.data[1:io.buffer.ptr-1]
+                convert(Vector{UInt8}, io.buffer.data[1:io.buffer.ptr-1])
             )
         )
         seekstart(io.buffer)
@@ -497,7 +497,7 @@ function Base.read(io::S3ReadBuffer, ::Type{UInt8})
                 "range" => "bytes=$(from_byte)-$(to_byte)"
             );
             aws_config=io.s3Path.aws_config
-        )# Testing with mock [from_byte+1:to_byte+1] and smaller buffersize
+        ) # Testing with mock [from_byte+1:to_byte+1] and smaller buffersize
 
         io.ptr = length(io.buffer) - length(result)
         io.buffer[(io.ptr+1):end] .= result

--- a/src/S3PATH.jl
+++ b/src/S3PATH.jl
@@ -246,6 +246,9 @@ end
 Base.write(s3Path::S3Path, content::AbstractString; blocksize=DEFAULTBUFFERSIZE) =
     Base.write(s3Path::S3Path, Vector{UInt8}(content); blocksize=blocksize)
 
+Base.write(s3Path::S3Path, content::Memory{UInt8}; blocksize=DEFAULTBUFFERSIZE) =
+    Base.write(s3Path::S3Path, convert(Vector{UInt8}, copy(content)); blocksize=blocksize)
+
 function Base.write(s3Path::S3Path, content::Vector{UInt8}; blocksize=DEFAULTBUFFERSIZE)
 
     if sizeof(content) < blocksize

--- a/test/test_S3Path.jl
+++ b/test/test_S3Path.jl
@@ -44,7 +44,7 @@
             Dict(
                 "body" => """
                     <CreateBucketConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-                    <LocationConstraint>Europe</LocationConstraint>
+                    <LocationConstraint>eu-central-1</LocationConstraint>
                     </CreateBucketConfiguration >
                 """
         ); aws_config = aws_config)

--- a/test/test_S3WriteBuffer.jl
+++ b/test/test_S3WriteBuffer.jl
@@ -4,7 +4,7 @@
     const written = Vector{UInt8}()
 
     # Mock Relevant Methods
-    function Base.write(io::S3PATH.S3Path, content::Vector{UInt8})
+    function Base.write(io::S3PATH.S3Path, content::Vector{UInt8}; blocksize=S3PATH.DEFAULTBUFFERSIZE)
         append!(written, content)
     end
 
@@ -74,7 +74,7 @@ end
     const written = Vector{UInt8}()
 
     # Mock Relevant Methods
-    function Base.write(io::S3PATH.S3Path, content::Vector{UInt8})
+    function Base.write(io::S3PATH.S3Path, content::Vector{UInt8}; blocksize=DEFAULTBUFFERSIZE)
         append!(written, content)
     end
 


### PR DESCRIPTION
It seems that the data field in the IOBuffer is now a Memory{UInt8} instead of a Vector{UInt8}.